### PR TITLE
Dash parser fixes

### DIFF
--- a/src/semantics.lem
+++ b/src/semantics.lem
@@ -1337,7 +1337,7 @@ and step_eval s0 checked stmt =
   | EvalLoop linno ((sstr,stackmark) as ctx) src interactive shell_level ->
      (* INVARIANT: you must call parse_cleanup sstr if you're leaving the eval loop *)
      let s1 = show_changed_jobs DeleteJobs Sh_monitor s0 in
-     let (s2, parsed) = parse_next s1 interactive stackmark in
+     let (s2, parsed) = parse_next s1 interactive in
      check_traps
        (match parsed with
         | ParseDone -> 
@@ -1347,7 +1347,7 @@ and step_eval s0 checked stmt =
              then (write_stderr "Use \"exit\" to leave the shell.\n" s2, 
                    EvalLoop linno ctx src interactive shell_level)
              else 
-               let _ = parse_cleanup sstr shell_level in
+               let _ = parse_cleanup sstr stackmark shell_level in
                (s2, Done)
            in
            (XSEval linno src "done", s3, c)
@@ -1357,7 +1357,7 @@ and step_eval s0 checked stmt =
              if is_interactive_mode interactive && is_toplevel shell_level 
              then EvalLoop linno ctx src interactive shell_level
              else 
-               let _ = parse_cleanup sstr shell_level in
+               let _ = parse_cleanup sstr stackmark shell_level in
                let catching_errors = not (checked_exit checked) && 
                                        Set.member Sh_errexit s1.sh.opts in
                let exit_on_error = catching_errors || not (is_interactive s3) in
@@ -1380,12 +1380,12 @@ and step_eval s0 checked stmt =
            (XSEval linno src "", s3,
             EvalLoopCmd (linno+1) ctx src interactive shell_level c)
         end)
-  | EvalLoopCmd linno ((sstr,_stackmark) as ctx) src interactive shell_level c ->
+  | EvalLoopCmd linno ((sstr,stackmark) as ctx) src interactive shell_level c ->
      (* INVARIANT: you must call parse_cleanup sstr shell_level if you're leaving the eval loop *)
      let (step, s1, c') = step_eval s0 checked c in
      match c' with
      | Exit -> 
-        let _ = parse_cleanup sstr shell_level in 
+        let _ = parse_cleanup sstr stackmark shell_level in
         (step, s1, Exit)
      | Done -> 
         (step, s1, EvalLoop linno ctx src interactive shell_level)
@@ -1395,7 +1395,7 @@ and step_eval s0 checked stmt =
           then (XSNested (XSEval linno src "return at top level") step,
                 EvalLoop linno ctx src interactive shell_level)
           else 
-            let _ = parse_cleanup sstr shell_level in
+            let _ = parse_cleanup sstr stackmark shell_level in
             if parse_source_for_dot src
             then (XSNested (XSEval linno src "return from dot") step,
                   Done)
@@ -1413,7 +1413,7 @@ and step_eval s0 checked stmt =
              if not (is_toplevel shell_level) && parse_source_propagates_control src
              then
                (* when break/continue occur in an eval, allow it! *)
-               let _ = parse_cleanup sstr shell_level in
+               let _ = parse_cleanup sstr stackmark shell_level in
                c'
              else 
                (* when they occur at the toplevel or in dot, ignore them *)

--- a/src/semantics.lem
+++ b/src/semantics.lem
@@ -1351,8 +1351,8 @@ and step_eval s0 checked stmt =
                (s2, Done)
            in
            (XSEval linno src "done", s3, c)
-        | ParseError -> 
-           let s3 = exit_with 2 s2 in
+        | ParseError s ->
+           let s3 = exit_with 2 (if s = "" then s2 else (write_stderr s s2)) in
            let c' =
              if is_interactive_mode interactive && is_toplevel shell_level 
              then EvalLoop linno ctx src interactive shell_level

--- a/src/shim.ml
+++ b/src/shim.ml
@@ -380,7 +380,12 @@ let parse_init src =
          None
        with Unix.Unix_error(_,_,_) -> bad_file file "unreadable"
 
-let parse_done m_ss =
+let parse_done m_ss m_smark =
+  begin
+    match m_smark with
+    | None -> ()
+    | Some ms -> Dash.pop_stack ms
+  end;
   Dash.popfile ();
   begin
     match m_ss with
@@ -388,7 +393,7 @@ let parse_done m_ss =
     | Some ss -> Dash.free_stack_string ss
   end
 
-let parse_next i m_smark : parse_result =
+let parse_next i : parse_result =
   let stackmark = Dash.init_stack () in
   let res =
     match Dash.parse_next ~interactive:(is_interactive_mode i) () with

--- a/src/smoosh.lem
+++ b/src/smoosh.lem
@@ -10,15 +10,15 @@ declare ocaml target_rep function stack_init = `Dash.init_stack`
 val stack_pop : stackmark -> unit
 declare ocaml target_rep function stack_pop = `Dash.pop_stack`
 
-val parse_done : maybe dash_string -> unit
+val parse_done : maybe dash_string -> maybe stackmark -> unit
 declare ocaml target_rep function parse_done = `Shim.parse_done`
 
-val parse_next_internal : interactivity_mode -> maybe stackmark -> parse_result
+val parse_next_internal : interactivity_mode -> parse_result
 declare ocaml target_rep function parse_next_internal = `Shim.parse_next`
 
-val parse_next : forall 'a. OS 'a => os_state 'a -> interactivity_mode -> maybe stackmark -> os_state 'a * parse_result
-let parse_next s0 interactive stackmark =
-  match parse_next_internal interactive stackmark with
+val parse_next : forall 'a. OS 'a => os_state 'a -> interactivity_mode -> os_state 'a * parse_result
+let parse_next s0 interactive =
+  match parse_next_internal interactive with
   | ParseDone    -> (s0,ParseDone)
   | ParseError s -> (s0,ParseError s)
   | ParseNull    -> (s0,ParseNull)
@@ -31,6 +31,6 @@ let parse_next s0 interactive stackmark =
      (s1, ParseStmt c)
   end
 
-val parse_cleanup : maybe dash_string -> shell_level -> unit
-let parse_cleanup mss shell_level =
-  if is_toplevel shell_level then () else parse_done mss
+val parse_cleanup : maybe dash_string -> maybe stackmark -> shell_level -> unit
+let parse_cleanup mss smark shell_level =
+  if is_toplevel shell_level then () else parse_done mss smark

--- a/src/smoosh.lem
+++ b/src/smoosh.lem
@@ -19,10 +19,10 @@ declare ocaml target_rep function parse_next_internal = `Shim.parse_next`
 val parse_next : forall 'a. OS 'a => os_state 'a -> interactivity_mode -> maybe stackmark -> os_state 'a * parse_result
 let parse_next s0 interactive stackmark =
   match parse_next_internal interactive stackmark with
-  | ParseDone   -> (s0,ParseDone)
-  | ParseError  -> (s0,ParseError)
-  | ParseNull   -> (s0,ParseNull)
-  | ParseStmt c ->
+  | ParseDone    -> (s0,ParseDone)
+  | ParseError s -> (s0,ParseError s)
+  | ParseNull    -> (s0,ParseNull)
+  | ParseStmt  c ->
      let s1 = 
        if Set.member Sh_verbose s0.sh.opts
        then safe_write_stderr (string_of_stmt c ^ "\n") s0

--- a/src/smoosh_prelude.lem
+++ b/src/smoosh_prelude.lem
@@ -1058,7 +1058,7 @@ and evaluation_step =
 
 and parse_result =
   | ParseDone
-  | ParseError
+  | ParseError of string
   | ParseNull
   | ParseStmt of stmt
 


### PR DESCRIPTION
This is for handling cases like `${}`, `${,}`, `${+}`, etc. Without this, they would end up in an endless mutual recursion of `shim.parse_arg` and `shim.arg_char`, ending with a stack overflow:
```
Fatal error: exception Stack overflow
Raised by primitive operation at file "shim.ml", line 277, characters 22-34
Called from file "shim.ml", line 253, characters 20-54
Called from file "shim.ml", line 305, characters 25-67
Called from file "shim.ml", line 305, characters 25-67
```
...repeating endlessly.

With this patch, the output is:
```
smoosh: bad substitution
```