### PR TITLE
Switch quoting to use double-quotes

### DIFF
--- a/src/smoosh_prelude.lem
+++ b/src/smoosh_prelude.lem
@@ -1437,7 +1437,8 @@ let rec symbolic_string_of_intermediate_fields ifs =
 val fields_of_expanded_words : expanded_words -> fields
 let fields_of_expanded_words w = [symbolic_string_of_expanded_words false w]
 
-let quoted_chars = toCharList "'\\"
+let quoted_chars = toCharList "|&;<>()$`\\\"'*?[#˜=% \t\n"
+let escaped_chars = toCharList "$`\"\\\n"
 
 val quote_cl : list char -> list char * bool
 let rec quote_cl cs =
@@ -1445,16 +1446,16 @@ let rec quote_cl cs =
   | [] -> ([], false)
   | c::cs -> 
      let (cs', needs_quotes) = quote_cl cs in
-     if elem c quoted_chars
+     if elem c escaped_chars
      then (#'\\'::c::cs', true)
-     else (c::cs', needs_quotes || is_whitespace c)
+     else (c::cs', needs_quotes || elem c quoted_chars)
   end
 
 val quote : string -> string
 let quote s = 
   let (cs, needs_quotes) = quote_cl (toCharList s) in
   let s' = toString cs in
-  if needs_quotes then "'" ^ s' ^ "'" else s'
+  if needs_quotes then "\"" ^ s' ^ "\"" else s'
                                     
 (* Number type helpers *)
 


### PR DESCRIPTION
See section 2.2.2.

This fixes the parse issue in the modernish test suite that is triggering the bug in issue #5 (but not the actual bug).

To reproduce the issue, try the following:
```
export FOO="a'"
eval $(export -p)
```
In this case `export -p` will print `export FOO='a\''`, where the second single-quote won't be escaped but instead is parsed as a real single-quote, and the third ends up being an unmatched opening quote.

This also makes most of the "weird noise on native Linux/VM" go away, as `export FOO="foo;bar"` printed by `export -p` and `eval`ed  is now properly quoted and won't be parsed as two separate commands.