### PR TITLE
Escape double quotes in case patterns

### DIFF
--- a/src/pattern.lem
+++ b/src/pattern.lem
@@ -266,6 +266,7 @@ let rec parse_quoted_pattern (pat:list char)
   match pat with
   | [] -> Left "unterminated quote"
   | #'\"'::pat' -> Right (pat', [])
+  | #'\\'::c::pat' -> recur pat' [Lit c]
   | c::pat' -> recur pat' [Lit c]
   end  
 

--- a/src/smoosh_prelude.lem
+++ b/src/smoosh_prelude.lem
@@ -1406,11 +1406,15 @@ let rec symbolic_string_of_expanded_words for_pattern w =
   match w with
   | [] -> symbolic_string_of_string ""
   | UsrF::ws -> symbolic_string_of_string " " ++ symbolic_string_of_expanded_words for_pattern ws
-  | ExpS s::ws -> symbolic_string_of_string s ++ symbolic_string_of_expanded_words for_pattern ws
+  | ExpS s::ws ->
+     let ss = symbolic_string_of_string s in
+     (if for_pattern
+      then concatMap (escape_sc [#'\"']) ss
+      else ss) ++ symbolic_string_of_expanded_words for_pattern ws
   | DQuo ss::ws -> 
     (* we don't include the quotes, since they'll be ultimately erased anyway! *)
      (if for_pattern 
-      then [C #'\"'] ++ ss ++ [C #'\"']
+      then [C #'\"'] ++ escape_quotes ss ++ [C #'\"']
       else ss) ++ symbolic_string_of_expanded_words for_pattern ws
   | At fs::ws -> 
      (* we collapse the result of $@ expansion, too. special cased in expand_control *)

--- a/tests/shell/semantics.case.escape.quotes.out
+++ b/tests/shell/semantics.case.escape.quotes.out
@@ -1,0 +1,3 @@
+Literal: OK
+Unquoted: OK
+Quoted: OK

--- a/tests/shell/semantics.case.escape.quotes.test
+++ b/tests/shell/semantics.case.escape.quotes.test
@@ -1,0 +1,16 @@
+foo=\"
+echo -n Literal: ''
+case "$foo" in
+    \" ) echo OK ;;
+    * ) echo NOT OK ;;
+esac
+echo -n Unquoted: ''
+case "$foo" in
+    $foo ) echo OK ;;
+    * ) echo NOT OK ;;
+esac
+echo -n Quoted: ''
+case "$foo" in
+    "$foo" ) echo OK ;;
+    * ) echo NOT OK ;;
+esac


### PR DESCRIPTION
This fixes the issue with `case` mentioned in #21, which turned out to be unrelated to that issue. Here the problem is that the parser for patterns considers the double quote as special, therefore it needs to be escaped in every case. Maybe this is an interface problem and the pattern matching should accept an input where it is clearer what is escaped and what is not, but for now this works.