### PR TITLE
Use OPAM to install Lem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "libdash"]
 	path = libdash
 	url = https://github.com/mgree/libdash
-	branch = master
 [submodule "lem"]
 	path = lem
 	url = https://github.com/rems-project/lem

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,8 @@ before_install:
   - (cd libdash; opam pin -y add .)
 
   # INSTALL lem
-  - opam exec -- make -C lem
-  - opam exec -- make -C lem install
-  - export LEMLIB=$(pwd)/lem/library
-  - export PATH="$(pwd)/lem/bin:$PATH"
+  - (cd lem; opam pin -y add .)
+  - export LEMLIB=$(opam var share)/lem/library
 
 install:
   # BUILD SMOOSH

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,11 @@ before_install:
 
   # INSTALL DEPS
   - opam install -y ocamlfind ocamlbuild num zarith extunix
+
+  # INSTALL DASH
   - (cd libdash; opam pin -y add .)
 
-  # INSTALL lem
+  # INSTALL LEM
   - (cd lem; opam pin -y add .)
   - export LEMLIB=$(opam var share)/lem/library
 


### PR DESCRIPTION
Updated Lem to the most recent release. We now use Lem's OPAM file to install Lem.

Some minor tweaks in `.gitmodules`.