### PR TITLE
Exit status carryover

### DIFF
--- a/src/semantics.lem
+++ b/src/semantics.lem
@@ -897,12 +897,18 @@ and step_eval s0 checked stmt =
      (* load exported variables, perform assignments *)
      let env = Map.fromList assigns in
      match run_command s1 opts checked prog args env with
-     | Right (s2, stmt', restore) -> 
-        (XSSimple ("ran " ^ string_of_symbolic_string prog), 
+     | Right (s2, Done, restore) ->
+        (XSSimple ("done running " ^ string_of_symbolic_string prog), 
          s2, 
          if catching_errors && s2.sh.exit_code <> 0
          then Exit
          else if restore 
+         then pushredir Done saved_fds 
+         else Done)
+     | Right (s2, stmt', restore) -> 
+        (XSSimple ("running " ^ string_of_symbolic_string prog), 
+         s2, 
+         if restore 
          then pushredir stmt' saved_fds 
          else stmt')
      | Left (s2,msg) -> 

--- a/tests/shell/semantics.errexit.carryover.out
+++ b/tests/shell/semantics.errexit.carryover.out
@@ -1,0 +1,2 @@
+It should be executed
+hello

--- a/tests/shell/semantics.errexit.carryover.test
+++ b/tests/shell/semantics.errexit.carryover.test
@@ -1,0 +1,6 @@
+set -e
+putsn() { echo "$@"; }
+false && true
+putsn "It should be executed"
+false && true
+/bin/echo hello


### PR DESCRIPTION
Resolves #41. A simple fix: only check for exit when `run_command` returns a `Done` (i.e., from some builtin) as opposed to a `Call` (from a function) or a `Wait` (from an executable).

Added a test (`tests/shell/semantics.exiterr.carryover.test`).