### PR TITLE
update zsh to 5.3.1-4+deb9u5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN sudo apt-get update
 RUN sudo apt-get install -y dash=0.5.8-2.4
 RUN sudo apt-get install -y --no-install-recommends bash=4.4-5
 RUN sudo apt-get install -y yash=2.43-1
-RUN sudo apt-get install -y zsh=5.3.1-4+b3 && echo 'emulate sh' >~/.zshrc
+RUN sudo apt-get install -y zsh=5.3.1-4+deb9u5 && echo 'emulate sh' >~/.zshrc
 RUN sudo apt-get install -y ksh=93u+20120801-3.1
 RUN sudo apt-get install -y mksh=54-2+b4
 


### PR DESCRIPTION
[DSA-5078-1](https://www.debian.org/security/2022/dsa-5078) ([CVE-2021-45444](https://security-tracker.debian.org/tracker/CVE-2021-45444)) has been fixed via `5.3.1-4+deb9u5` which is now shipped in `ocaml/opam2:debian-9`.

This caused `./build.sh` to fail with:

```
#0 0.329 Reading package lists...
#0 0.691 Building dependency tree...
#0 0.754 Reading state information...
#0 0.774 Some packages could not be installed. This may mean that you have
#0 0.774 requested an impossible situation or if you are using the unstable
#0 0.774 distribution that some required packages have not yet been created
#0 0.774 or been moved out of Incoming.
#0 0.774 The following information may help to resolve the situation:
#0 0.774
#0 0.774 The following packages have unmet dependencies:
#0 0.805  zsh : Depends: zsh-common (= 5.3.1-4) but 5.3.1-4+deb9u5 is to be installed
#0 0.808 E: Unable to correct problems, you have held broken packages.
```